### PR TITLE
Remove name label

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -34,7 +34,6 @@ resource "google_storage_bucket" "bucket" {
   }
   labels = merge(var.labels, {
     location      = lower(var.location)
-    name          = lower(var.name)
     storage_class = lower(var.storage_class)
   })
 


### PR DESCRIPTION
Importing firestore buckets fails because setting the `name` label doesn't seem to be allowed, we get a 400 response from the GCP API.
Also, the bucket already has a name, a name label is redundant.
I don't know if it's a constraint that won't allow the `name` label from being updated, but either way I think its value is debatable.