### PR TITLE
Switch lifecycle action storage_class field to optional

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -89,7 +89,7 @@ variable "lifecycle_rule" {
   type = object({
     action = object({
       type          = string
-      storage_class = string
+      storage_class = optional(string)
     })
     condition = object({
       age                = optional(number)


### PR DESCRIPTION
Per the Terraform [documentation](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket):

The action block supports:

type - The type of the action of this Lifecycle Rule. Supported values include: Delete and SetStorageClass.

storage_class - (Required if action type is SetStorageClass) 
The target [Storage Class](https://cloud.google.com/storage/docs/storage-classes) of objects affected by this Lifecycle Rule. Supported values include: STANDARD, MULTI_REGIONAL, REGIONAL, NEARLINE, COLDLINE, ARCHIVE.

Since the action will not always be `SetStorageClass`, the `storage_class` field should be optional as well.
