### PR TITLE
Add support for public_access_prevention

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -40,7 +40,7 @@ resource "google_storage_bucket" "bucket" {
     location      = lower(var.location)
     storage_class = lower(var.storage_class)
   })
-  
+
   dynamic "encryption" {
     for_each = var.encryption_key == null ? [] : [""]
 

--- a/main.tf
+++ b/main.tf
@@ -30,6 +30,9 @@ resource "google_storage_bucket" "bucket" {
   public_access_prevention    = var.public_access_prevention
   force_destroy               = var.force_destroy
   uniform_bucket_level_access = var.uniform_bucket_level_access
+  autoclass {
+    enabled = var.autoclass
+  }
   versioning {
     enabled = var.versioning
   }

--- a/main.tf
+++ b/main.tf
@@ -27,6 +27,7 @@ resource "google_storage_bucket" "bucket" {
   project                     = var.project_id
   location                    = var.location
   storage_class               = var.storage_class
+  public_access_prevention    = var.public_access_prevention
   force_destroy               = var.force_destroy
   uniform_bucket_level_access = var.uniform_bucket_level_access
   versioning {
@@ -36,7 +37,7 @@ resource "google_storage_bucket" "bucket" {
     location      = lower(var.location)
     storage_class = lower(var.storage_class)
   })
-
+  
   dynamic "encryption" {
     for_each = var.encryption_key == null ? [] : [""]
 

--- a/variables.tf
+++ b/variables.tf
@@ -129,6 +129,12 @@ variable "cors" {
   default = null
 }
 
+variable "autoclass" {
+  description = "Automatically transitions objects in your bucket to appropriate storage classes based on each object's access pattern."
+  type        = bool
+  default     = false
+}
+
 variable "public_access_prevention" {
   description = "Prevents public access to a bucket. Acceptable values are inherited or enforced. If inherited, the bucket uses public access prevention, only if the bucket is subject to the public access prevention organization policy constraint."
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -128,3 +128,9 @@ variable "cors" {
   })
   default = null
 }
+
+variable "public_access_prevention" {
+  description = "Prevents public access to a bucket. Acceptable values are inherited or enforced. If inherited, the bucket uses public access prevention, only if the bucket is subject to the public access prevention organization policy constraint."
+  type        = string
+  default     = "inherited"
+}

--- a/versions.tf
+++ b/versions.tf
@@ -16,4 +16,10 @@
 
 terraform {
   required_version = ">= 1.3.8"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 4.42"
+    }
+  }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -19,7 +19,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.42"
+      version = ">= 4.55"
     }
   }
 }


### PR DESCRIPTION
[`public_access_prevention` is a new feature in GCS](https://cloud.google.com/storage/docs/public-access-prevention) that prevents any policy from being added to a bucket that would inherently make the contents of the bucket public:

>Public access prevention protects Cloud Storage buckets and objects from being accidentally exposed to the public. When you enforce public access prevention, no one can make data in applicable buckets public through IAM policies or ACLs.

Also adds support for autoclass:

>While set to true, autoclass automatically transitions objects in your bucket to appropriate storage classes based on each object's access pattern.