### PR TITLE
Make autoclass dynamic again

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -30,9 +30,6 @@ resource "google_storage_bucket" "bucket" {
   public_access_prevention    = var.public_access_prevention
   force_destroy               = var.force_destroy
   uniform_bucket_level_access = var.uniform_bucket_level_access
-  autoclass {
-    enabled = var.autoclass
-  }
   versioning {
     enabled = var.versioning
   }
@@ -40,6 +37,13 @@ resource "google_storage_bucket" "bucket" {
     location      = lower(var.location)
     storage_class = lower(var.storage_class)
   })
+
+  dynamic "autoclass" {
+    count = var.autoclass ? 1 : 0
+    content {
+      enabled = var.autoclass
+    }
+  }
 
   dynamic "encryption" {
     for_each = var.encryption_key == null ? [] : [""]

--- a/variables.tf
+++ b/variables.tf
@@ -130,7 +130,7 @@ variable "cors" {
 }
 
 variable "autoclass" {
-  description = "Automatically transitions objects in your bucket to appropriate storage classes based on each object's access pattern."
+  description = "Automatically transitions objects in your bucket to appropriate storage classes based on each object's access pattern.  Defaults to false."
   type        = bool
   default     = false
 }


### PR DESCRIPTION
Autoclass is great - except it's not.  Although the default for autoclass is `false`, explicitly setting this attribute on the GCS bucket wants to nuke everything, which is bad.  This makes the autoclass attribute "optional".  Buyer beware.